### PR TITLE
Add clarifying comment next to the github token parameter

### DIFF
--- a/.github/workflows/tryhackme-update-badge.yml
+++ b/.github/workflows/tryhackme-update-badge.yml
@@ -15,4 +15,5 @@ jobs:
         with:
           # Replace with your tryhackme username
           username: "p4p1"
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}} # Do not paste your github token here - this is a placeholder
+                                                  # and will pull your github token automatically

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ jobs:
         with:
           # Replace with your tryhackme username
           username: "<USERNAME>"
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}} # Do not paste your github token here - this is a placeholder
+                                                  # and will pull your github token automatically
 ```
 5. Create a assets/ folder inside of your username repo
 6. Add the following markdown in your read me and add your username:


### PR DESCRIPTION
The notation of the github token placeholder could be misleading and make someone pasting a github access token there. The added comments should clarify this and prevent people from leaking a token.